### PR TITLE
Make the titles 'Homework', 'Problem' and 'Solution' editable.

### DIFF
--- a/homework.cls
+++ b/homework.cls
@@ -57,7 +57,8 @@
 \newcommand{\@course}{}
 \newcommand{\@term}{}
 \newcommand{\@hwnum}{}
-\newcommand{\@hwtitle}{{\@course} Homework {\@hwnum}}
+\newcommand{\@hwtype}{Homework}
+\newcommand{\@hwtitle}{{\@course} {\@hwtype} {\@hwnum}}
 
 % Macros to define the homework details in .tex files using this class
 % These should be used in the preamble
@@ -65,6 +66,7 @@
 \newcommand{\course}[1]{\renewcommand{\@course}{#1}}
 \newcommand{\term}[1]{\renewcommand{\@term}{#1}}
 \newcommand{\hwnum}[1]{\renewcommand{\@hwnum}{#1}}
+\newcommand{\hwtype}[1]{\renewcommand{\@hwtype}{#1}}
 
 
 %%%%%%%%%%%%%%%%%%%
@@ -106,7 +108,7 @@
     \begin{titlepage}
     \begin{center}
       \vspace*{1cm}
-      \Huge Homework \@hwnum\\
+      \Huge \hwtype \@hwnum\\
       \vspace*{1cm}
       \Large\@name\\
       \vspace*{1cm}

--- a/homework.cls
+++ b/homework.cls
@@ -235,6 +235,8 @@
 
 % Environment for writing homework problems
 \newcommand{\problem@title}{Problem}
+\newcommand{\problemtitle}[1]{\renewcommand{\problem@title}{#1}}
+
 \theoremstyle{definition}
 \newtheorem{@problem}{\problem@title}
 \numberwithin{equation}{@problem}
@@ -304,6 +306,8 @@
 
 % Environment for writing solutions
 \newcommand{\solution@title}{Solution}
+\newcommand{\solutiontitle}[1]{\renewcommand{\solution@title}{#1}}
+
 \newenvironment{solution}
 {
   \begin{proof}[\normalfont\bfseries\solution@title]%


### PR DESCRIPTION
I would like this awesome class to be useful even if the typeset text is not in English.

`\hwtype{...}` sets how 'Homework' is written in the title. `\solutiontitle{...}` and `\problemtitle{...}` set a new title for the corresponding environment.
