### PR TITLE
Add way to display the number of points awarded for a problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ The following environments are provided to typeset the homework.
   wraps the solution to a problem.
 * `parts`:
   enumerates parts of a multiple-part problem.
+  If multiple `parts` environments are used in a single `problem` environment,
+  labels will resume unless you use the `\unresume` command right after the
+  beginning of each `parts` environment.
   New parts are declared using the `\part` command.
   The part labels can be customized by providing one of the following options to
   the `parts` environment:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ document by using the following commands.
   Replace `<title>` with the desired label for problems created with the
   `problem` environment (e.g., *Exercise* or *Question*).
   The default is *Problem*.
+* `\pointlabel{<label>}`/`\pointslabel{<label>}`:
+  Replace `<label>` with the desired labels for points (singular/plural) for
+  problems created with the `problem` environment (e.g., *credit*/*credits*).
+  The default is *point*/*points*.
 * `\solutiontitle{<title>}`:
   Replace `<title>` with the desired label for solutions created with the
   `solution` environment (e.g., *Proof*, *Answer*, or a label in another
@@ -125,6 +129,8 @@ The following environments are provided to typeset the homework.
   By default, problems are numbered beginning at `1`.
   To change the number of a given problem to `n`, use the command
   `\problemnumber{n}` before the `problem` environment.
+  To display the number of points `p` awarded for a given problem, add `p` as an
+  argument to the `problem` environment, e.g. `\begin{problem}[p]`.
 * `solution`:
   wraps the solution to a problem.
 * `parts`:

--- a/homework.cls
+++ b/homework.cls
@@ -339,13 +339,15 @@
   , partopsep=100pt
   , labelindent=0pt
   , labelwidth=4.5em
-  , labelsep=0.5em,
+  , labelsep=0.5em
+  , resume
   ]%
 }
 {
   \endenumerate
 }
 \renewcommand{\part}{\item}
+\newcommand{\unresume}{\setcounter{enumi}{0}}
 
 %----------------------%
 % Solution Environment %

--- a/homework.cls
+++ b/homework.cls
@@ -262,7 +262,6 @@
 %---------------------%
 % Problem Environment %
 %---------------------%
-
 \RequirePackage{framed}
 \newcounter{@problemNumber}
 \theoremstyle{definition}

--- a/homework.cls
+++ b/homework.cls
@@ -76,6 +76,8 @@
 
 \newcommand{\@hwType}{Homework}
 \newcommand{\@problemTitle}{Problem}
+\newcommand{\@pointLabel}{point}
+\newcommand{\@pointsLabel}{points}
 \newcommand{\@solutionTitle}{Solution}
 \newcommand{\@hwtitle}{\@course\ \@hwType\ \@hwNum}
 
@@ -93,6 +95,8 @@
 \newcommand{\hwtype}[1]{\renewcommand{\@hwType}{#1}}
 \newcommand{\solutiontitle}[1]{\renewcommand{\@solutionTitle}{#1}}
 \newcommand{\problemtitle}[1]{\renewcommand{\@problemTitle}{#1}}
+\newcommand{\pointlabel}[1]{\renewcommand{\@pointLabel}{#1}}
+\newcommand{\pointslabel}[1]{\renewcommand{\@pointsLabel}{#1}}
 
 
 %%%%%%%%%%%%%%%%%%%
@@ -258,6 +262,7 @@
 %---------------------%
 % Problem Environment %
 %---------------------%
+
 \RequirePackage{framed}
 \newcounter{@problemNumber}
 \theoremstyle{definition}
@@ -272,7 +277,14 @@
     \fi
   \fi
   \notbool{HW@noboxes}{\framed\vspace{-1.5ex}}{}
-  \@problem[#1]
+  \@problem
+  \def\temp{#1}\ifx\temp\empty\else
+    \ifnum#1=1
+      \textit{(#1 \@pointLabel)}
+    \else
+      \textit{(#1 \@pointsLabel)}
+    \fi
+  \fi
   \pdfbookmark{\@problemTitle\ \arabic{@problem}}{prob-\arabic{@problem}}
 }
 {


### PR DESCRIPTION
I've added a way to display the number of points awarded for a problem to `homework.cls` and modified `README.md` accordingly. In order to achieve this, I had to change `\@problem[#1]` to `\@problem` in the body of the `problem` environment definition.

I'm not sure whether I've done this in the most elegant way -- this is my first attempt at advanced LaTeX.

EDIT: Showing a screenshot of how the result looks probably won't hurt (note that it's _points_ by default):
<img width="440" alt="screen shot 2015-11-22 at 17 26 35" src="https://cloud.githubusercontent.com/assets/1944410/11325256/b1446b46-9149-11e5-9ed3-8eecc422d46f.png">
